### PR TITLE
fix: prevent ANR during playback (develop)

### DIFF
--- a/app/shared/src/main/kotlin/dev/aaa1115910/bv/viewmodel/VideoPlayerV3ViewModel.kt
+++ b/app/shared/src/main/kotlin/dev/aaa1115910/bv/viewmodel/VideoPlayerV3ViewModel.kt
@@ -399,12 +399,15 @@ class VideoPlayerV3ViewModel(
         logger.fInfo { "Select audio: $audioItem" }
         addLogs("音频编码：${(Audio.fromCode(audioItem?.codecId ?: 0))?.getDisplayName(BVApp.context) ?: "未知"}")
 
-        withContext(Dispatchers.Main) {
-            currentVideoHeight = videoItem?.height ?: 0
-            currentVideoWidth = videoItem?.width ?: 0
-            logger.info { "Video url: $videoUrl" }
-            logger.info { "Audio url: $audioUrl" }
+        currentVideoHeight = videoItem?.height ?: 0
+        currentVideoWidth = videoItem?.width ?: 0
+        logger.info { "Video url: $videoUrl" }
+        logger.info { "Audio url: $audioUrl" }
+        // 将 playUrl 移到 IO 线程，避免主线程阻塞
+        withContext(Dispatchers.IO) {
             videoPlayer!!.playUrl(videoUrl, audioUrl)
+        }
+        withContext(Dispatchers.Main) {
             videoPlayer!!.prepare()
             showBuffering = true
         }

--- a/player/core/src/main/kotlin/dev/aaa1115910/bv/player/impl/exo/ExoMediaPlayer.kt
+++ b/player/core/src/main/kotlin/dev/aaa1115910/bv/player/impl/exo/ExoMediaPlayer.kt
@@ -18,6 +18,7 @@ import dev.aaa1115910.bv.player.AbstractVideoPlayer
 import dev.aaa1115910.bv.player.OkHttpUtil
 import dev.aaa1115910.bv.player.VideoPlayerOptions
 import dev.aaa1115910.bv.util.formatHourMinSec
+import java.util.concurrent.TimeUnit
 
 @OptIn(UnstableApi::class)
 class ExoMediaPlayer(
@@ -28,11 +29,15 @@ class ExoMediaPlayer(
     protected var mMediaSource: MediaSource? = null
 
     @OptIn(UnstableApi::class)
-    private val dataSourceFactory =
-        OkHttpDataSource.Factory(OkHttpUtil.generateCustomSslOkHttpClient(context)).apply {
-            options.userAgent?.let { setUserAgent(it) }
-            options.referer?.let { setDefaultRequestProperties(mapOf("referer" to it)) }
-        }
+    private val dataSourceFactory = OkHttpDataSource.Factory(
+        OkHttpUtil.generateCustomSslOkHttpClient(context).newBuilder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .build()
+    ).apply {
+        options.userAgent?.let { setUserAgent(it) }
+        options.referer?.let { setDefaultRequestProperties(mapOf("referer" to it)) }
+    }
 
     init {
         initPlayer()


### PR DESCRIPTION
Fix player ANR crash:
- Move videoPlayer.playUrl() to IO dispatcher
- Add 15s connect/read timeout to ExoDataSource
- Should reduce crashes when CDN is slow