### PR TITLE
feat: add software video renderer option (lastAndroid5)

### DIFF
--- a/.github/workflows/lastAndroid5.yml
+++ b/.github/workflows/lastAndroid5.yml
@@ -51,7 +51,7 @@ jobs:
           base64 -d -i encoded_key > key.jks
 
       - name: Build apk
-        run: ./gradlew assembleDefaultAlpha assembleDefaultDebug
+        run: ./gradlew assembleDefaultAlpha assembleDefaultDebug --stacktrace
 
       - name: Read alpha apk output metadata
         id: apk-meta-alpha


### PR DESCRIPTION
Add software video renderer option:
- Add enableSoftwareVideoRenderer to VideoPlayerOptions
- Add enableSoftwareVideoRenderer to Prefs
- Add TV settings UI for software video renderer
- Add mobile settings UI for software video renderer
- ExoPlayer uses software renderer when enabled