### PR TITLE
feat: ANR fix & software video renderer (lastAndroid5)

### DIFF
--- a/app/mobile/src/main/kotlin/dev/aaa1115910/bv/mobile/activities/VideoPlayerActivity.kt
+++ b/app/mobile/src/main/kotlin/dev/aaa1115910/bv/mobile/activities/VideoPlayerActivity.kt
@@ -83,7 +83,9 @@ class VideoPlayerActivity : ComponentActivity() {
             referer = when (Prefs.apiType) {
                 ApiType.Web -> getString(R.string.video_player_referer)
                 ApiType.App -> null
-            }
+            },
+            enableFfmpegAudioRenderer = Prefs.enableFfmpegAudioRenderer,
+            enableSoftwareVideoRenderer = Prefs.enableSoftwareVideoRenderer
         )
         val videoPlayer = when (Prefs.playerType) {
             PlayerType.Media3 -> ExoPlayerFactory().create(this, options)

--- a/app/mobile/src/main/kotlin/dev/aaa1115910/bv/mobile/screen/settings/details/PlayContent.kt
+++ b/app/mobile/src/main/kotlin/dev/aaa1115910/bv/mobile/screen/settings/details/PlayContent.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.LocalContext
 import de.schnettler.datastore.manager.DataStoreManager
 import dev.aaa1115910.bv.dataStore
 import dev.aaa1115910.bv.mobile.component.preferences.RadioPreferenceItem
+import dev.aaa1115910.bv.mobile.component.preferences.SwitchPreferenceItem
 import dev.aaa1115910.bv.mobile.component.preferences.getOrDefault
 import dev.aaa1115910.bv.player.entity.Audio
 import dev.aaa1115910.bv.player.entity.Resolution
@@ -47,6 +48,11 @@ fun PlayContent(
             prefReq = PrefKeys.prefDefaultAudioRequest,
             summary = Audio.fromCode(prefs.getOrDefault(PrefKeys.prefDefaultAudioRequest))
                 ?.getDisplayName(context) ?: ""
+        )
+        SwitchPreferenceItem(
+            title = "启用视频软解",
+            summary = "使用软件解码器播放视频，可能解决硬解兼容性问题",
+            prefReq = PrefKeys.prefEnableSoftwareVideoRendererRequest
         )
     }
 }

--- a/app/shared/src/main/kotlin/dev/aaa1115910/bv/util/Prefs.kt
+++ b/app/shared/src/main/kotlin/dev/aaa1115910/bv/util/Prefs.kt
@@ -299,6 +299,17 @@ object Prefs {
             )
         }
 
+    var enableSoftwareVideoRenderer: Boolean
+        get() = runBlocking {
+            dsm.getPreferenceFlow(PrefKeys.prefEnableSoftwareVideoRendererRequest).first()
+        }
+        set(value) = runBlocking {
+            dsm.editPreference(
+                PrefKeys.prefEnableSoftwareVideoRenderer,
+                value
+            )
+        }
+
     var blacklistUser: Boolean
         get() = runBlocking { dsm.getPreferenceFlow(PrefKeys.prefBlacklistUserRequest).first() }
         set(value) = runBlocking { dsm.editPreference(PrefKeys.prefBlacklistUserKey, value) }
@@ -354,6 +365,7 @@ object PrefKeys {
     val prefPreferOfficialCdn = booleanPreferencesKey("prefer_official_cdn")
     val prefDefaultDanmakuMask = booleanPreferencesKey("prefer_enable_webmark")
     val prefEnableFfmpegAudioRenderer = booleanPreferencesKey("enable_ffmpeg_audio_renderer")
+    val prefEnableSoftwareVideoRenderer = booleanPreferencesKey("enable_software_video_renderer")
     val prefBlacklistUserKey = booleanPreferencesKey("blacklist_user")
     val prefThemeTypeKey = intPreferencesKey("theme_type")
 
@@ -407,6 +419,7 @@ object PrefKeys {
     val prefPreferOfficialCdnRequest = PreferenceRequest(prefPreferOfficialCdn, false)
     val prefDefaultDanmakuMaskRequest = PreferenceRequest(prefDefaultDanmakuMask, false)
     val prefEnableFfmpegEndererRequest = PreferenceRequest(prefEnableFfmpegAudioRenderer, false)
+    val prefEnableSoftwareVideoRendererRequest = PreferenceRequest(prefEnableSoftwareVideoRenderer, false)
     val prefBlacklistUserRequest = PreferenceRequest(prefBlacklistUserKey, false)
     val prefThemeTypeRequest = PreferenceRequest(prefThemeTypeKey, ThemeType.Auto.ordinal)
 }

--- a/app/shared/src/main/kotlin/dev/aaa1115910/bv/viewmodel/VideoPlayerV3ViewModel.kt
+++ b/app/shared/src/main/kotlin/dev/aaa1115910/bv/viewmodel/VideoPlayerV3ViewModel.kt
@@ -395,12 +395,15 @@ class VideoPlayerV3ViewModel(
         logger.fInfo { "Select audio: $audioItem" }
         addLogs("音频编码：${(Audio.fromCode(audioItem?.codecId ?: 0))?.getDisplayName(BVApp.context) ?: "未知"}")
 
-        withContext(Dispatchers.Main) {
-            currentVideoHeight = videoItem?.height ?: 0
-            currentVideoWidth = videoItem?.width ?: 0
-            logger.info { "Video url: $videoUrl" }
-            logger.info { "Audio url: $audioUrl" }
+        currentVideoHeight = videoItem?.height ?: 0
+        currentVideoWidth = videoItem?.width ?: 0
+        logger.info { "Video url: $videoUrl" }
+        logger.info { "Audio url: $audioUrl" }
+        // 将 playUrl 移到 IO 线程，避免主线程卡顿
+        withContext(Dispatchers.IO) {
             videoPlayer!!.playUrl(videoUrl, audioUrl)
+        }
+        withContext(Dispatchers.Main) {
             videoPlayer!!.prepare()
             showBuffering = true
         }

--- a/app/shared/src/main/res/values/strings.xml
+++ b/app/shared/src/main/res/values/strings.xml
@@ -219,6 +219,8 @@
     <string name="settings_other_alpha_title">Alpha 版更新</string>
     <string name="settings_other_ffmpeg_audio_renderer_text">尝试使用 FFmpeg 播放硬解不兼容的音频</string>
     <string name="settings_other_ffmpeg_audio_renderer_title">启用音频软解</string>
+    <string name="settings_other_software_video_renderer_title">启用视频软解</string>
+    <string name="settings_other_software_video_renderer_text">使用软件解码器播放视频，可能解决硬解兼容性问题</string>
     <string name="settings_other_firebase_text">这将帮助开发者更快地发现与解决大部分问题</string>
     <string name="settings_other_firebase_title">发送错误日志</string>
     <string name="settings_other_fps_text">在屏幕左上角显示 FPS，这需要重启 App</string>

--- a/app/tv/src/main/kotlin/dev/aaa1115910/bv/tv/activities/video/VideoPlayerV3Activity.kt
+++ b/app/tv/src/main/kotlin/dev/aaa1115910/bv/tv/activities/video/VideoPlayerV3Activity.kt
@@ -101,7 +101,8 @@ class VideoPlayerV3Activity : ComponentActivity() {
                 ApiType.Web -> getString(R.string.video_player_referer)
                 ApiType.App -> null
             },
-            enableFfmpegAudioRenderer = Prefs.enableFfmpegAudioRenderer
+            enableFfmpegAudioRenderer = Prefs.enableFfmpegAudioRenderer,
+            enableSoftwareVideoRenderer = Prefs.enableSoftwareVideoRenderer
         )
         val videoPlayer = when (Prefs.playerType) {
             PlayerType.Media3 -> ExoPlayerFactory().create(this, options)

--- a/app/tv/src/main/kotlin/dev/aaa1115910/bv/tv/screens/settings/content/OtherSetting.kt
+++ b/app/tv/src/main/kotlin/dev/aaa1115910/bv/tv/screens/settings/content/OtherSetting.kt
@@ -38,6 +38,7 @@ fun OtherSetting(
     var showFps by remember { mutableStateOf(Prefs.showFps) }
     var updateAlpha by remember { mutableStateOf(Prefs.updateAlpha) }
     var enableFfmpegAudioRenderer by remember { mutableStateOf(Prefs.enableFfmpegAudioRenderer) }
+    var enableSoftwareVideoRenderer by remember { mutableStateOf(Prefs.enableSoftwareVideoRenderer) }
 
     Column(
         modifier = modifier.fillMaxSize(),
@@ -117,6 +118,17 @@ fun OtherSetting(
                     onCheckedChange = {
                         enableFfmpegAudioRenderer = it
                         Prefs.enableFfmpegAudioRenderer = it
+                    }
+                )
+            }
+            item {
+                SettingSwitchListItem(
+                    title = stringResource(R.string.settings_other_software_video_renderer_title),
+                    supportText = stringResource(R.string.settings_other_software_video_renderer_text),
+                    checked = enableSoftwareVideoRenderer,
+                    onCheckedChange = {
+                        enableSoftwareVideoRenderer = it
+                        Prefs.enableSoftwareVideoRenderer = it
                     }
                 )
             }

--- a/player/core/src/main/kotlin/dev/aaa1115910/bv/player/VideoPlayerOptions.kt
+++ b/player/core/src/main/kotlin/dev/aaa1115910/bv/player/VideoPlayerOptions.kt
@@ -3,5 +3,6 @@ package dev.aaa1115910.bv.player
 data class VideoPlayerOptions(
     val userAgent: String? = null,
     val referer: String? = null,
-    val enableFfmpegAudioRenderer: Boolean = false
+    val enableFfmpegAudioRenderer: Boolean = false,
+    val enableSoftwareVideoRenderer: Boolean = false
 )

--- a/player/core/src/main/kotlin/dev/aaa1115910/bv/player/impl/exo/ExoMediaPlayer.kt
+++ b/player/core/src/main/kotlin/dev/aaa1115910/bv/player/impl/exo/ExoMediaPlayer.kt
@@ -52,6 +52,10 @@ class ExoMediaPlayer(
                     false -> DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF
                 }
             )
+            // 启用软解时，强制使用软件视频解码器
+            if (options.enableSoftwareVideoRenderer) {
+                setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER)
+            }
         }
         mPlayer = ExoPlayer
             .Builder(context)

--- a/player/core/src/main/kotlin/dev/aaa1115910/bv/player/impl/exo/ExoMediaPlayer.kt
+++ b/player/core/src/main/kotlin/dev/aaa1115910/bv/player/impl/exo/ExoMediaPlayer.kt
@@ -18,6 +18,7 @@ import dev.aaa1115910.bv.player.AbstractVideoPlayer
 import dev.aaa1115910.bv.player.OkHttpUtil
 import dev.aaa1115910.bv.player.VideoPlayerOptions
 import dev.aaa1115910.bv.util.formatHourMinSec
+import java.util.concurrent.TimeUnit
 
 @OptIn(UnstableApi::class)
 class ExoMediaPlayer(
@@ -28,11 +29,15 @@ class ExoMediaPlayer(
     protected var mMediaSource: MediaSource? = null
 
     @OptIn(UnstableApi::class)
-    private val dataSourceFactory =
-        OkHttpDataSource.Factory(OkHttpUtil.generateCustomSslOkHttpClient(context)).apply {
-            options.userAgent?.let { setUserAgent(it) }
-            options.referer?.let { setDefaultRequestProperties(mapOf("referer" to it)) }
-        }
+    private val dataSourceFactory = OkHttpDataSource.Factory(
+        OkHttpUtil.generateCustomSslOkHttpClient(context).newBuilder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .build()
+    ).apply {
+        options.userAgent?.let { setUserAgent(it) }
+        options.referer?.let { setDefaultRequestProperties(mapOf("referer" to it)) }
+    }
 
     init {
         initPlayer()


### PR DESCRIPTION
Changes:

1. **ANR Fix**:
   - Move videoPlayer.playUrl() to IO dispatcher
   - Add 15s connect/read timeout to ExoDataSource
   - Should reduce crashes when CDN is slow

2. **Software Video Renderer**:
   - Add enableSoftwareVideoRenderer to VideoPlayerOptions
   - Add enableSoftwareVideoRenderer to Prefs
   - Add TV settings UI for software video renderer
   - Add mobile settings UI for software video renderer
   - ExoPlayer uses software renderer when enabled