### PR TITLE
fix: detect TV device and redirect to TV launcher (lastAndroid5)

### DIFF
--- a/app/mobile/src/main/kotlin/dev/aaa1115910/bv/mobile/activities/MainActivity.kt
+++ b/app/mobile/src/main/kotlin/dev/aaa1115910/bv/mobile/activities/MainActivity.kt
@@ -1,5 +1,8 @@
 package dev.aaa1115910.bv.mobile.activities
 
+import android.app.UiModeManager
+import android.content.Intent
+import android.content.res.Configuration
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -9,6 +12,24 @@ import dev.aaa1115910.bv.mobile.theme.BVMobileTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        // 检测是否在 TV 上运行，如果是则跳转到 TV 版
+        if (isTvDevice()) {
+            try {
+                val tvMainActivity = Intent().apply {
+                    setClassName(
+                        this@MainActivity,
+                        "dev.aaa1115910.bv.tv.activities.MainActivity"
+                    )
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                startActivity(tvMainActivity)
+                finish()
+                return
+            } catch (e: Exception) {
+                // TV 版 Activity 不存在，继续使用手机版
+            }
+        }
+
         var keepSplashScreen = true
         installSplashScreen().apply {
             setKeepOnScreenCondition { keepSplashScreen }
@@ -22,5 +43,10 @@ class MainActivity : ComponentActivity() {
                 MobileMainScreen()
             }
         }
+    }
+
+    private fun isTvDevice(): Boolean {
+        val uiModeManager = getSystemService(UI_MODE_SERVICE) as UiModeManager
+        return uiModeManager.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION
     }
 }


### PR DESCRIPTION
Fix Chinese TV launchers that don't support LEANBACK_LAUNCHER:

- Check if running on TV using UiModeManager
- Redirect to TV MainActivity if on TV device
- Fallback to mobile if TV activity not found